### PR TITLE
PIN-4753: changed charts visualization

### DIFF
--- a/src/components/numbers/TopEServices.tsx
+++ b/src/components/numbers/TopEServices.tsx
@@ -298,7 +298,7 @@ const TopEservices = ({ data }: TopEServicesProps) => {
         notMergeData
         chartOptions={chartOptions}
         tableData={tableData}
-        chartHeight={480}
+        chartHeight={580}
         info={Info}
         ariaLabel={`Grafico che mostra la top 10 degli enti che pubblicano più e-service. ${tableData.body
           .map((i) => `${i[0]} con ${i[1]} iscritti`)

--- a/src/components/numbers/TopEServices.tsx
+++ b/src/components/numbers/TopEServices.tsx
@@ -17,6 +17,7 @@ import {
   macroCategoriesOptions,
   MACROCATEGORIES,
   MACROCATEGORIES_COLORS_MAP,
+  BAR_CHART_NUMERIC_LABEL_COLOR,
 } from '@/configs/constants.config'
 import { Typography, useMediaQuery, useTheme } from '@mui/material'
 import { formatThousands } from '@/utils/formatters.utils'
@@ -41,6 +42,7 @@ const TopEservices = ({ data }: TopEServicesProps) => {
   const xAxisColorLabel = useTheme().palette.grey[800]
   const mediaQuerySm = useTheme().breakpoints.values.sm
   const isMobile = useMediaQuery(useTheme().breakpoints.down('sm'))
+  const textColorPrimary = useTheme().palette.text.primary
 
   const formattedChartsData = React.useMemo(() => {
     const result: TopEservicesMetric = {
@@ -183,11 +185,17 @@ const TopEservices = ({ data }: TopEServicesProps) => {
         stack: 'total',
         label: {
           show: false,
+          position: 'insideRight',
+          distance: -5,
+          align: 'left',
+          backgroundColor: 'white',
+          color: BAR_CHART_NUMERIC_LABEL_COLOR,
         },
         color: MACROCATEGORIES_COLORS_MAP.get(MACROCATEGORIES[key as MacroCategory['id']]),
         emphasis: {
           focus: 'series',
         },
+        barWidth: 12,
         data: groupedDataByMacroCategories[key as MacroCategory['id']],
       }
     })
@@ -225,6 +233,20 @@ const TopEservices = ({ data }: TopEServicesProps) => {
       yAxis: {
         type: 'category',
         data: yAxisData,
+        axisTick: {
+          show: false,
+        },
+        axisLabel: {
+          backgroundColor: 'white',
+          align: 'left',
+          margin: -8,
+          padding: [0, 0, 10, 0],
+          verticalAlign: 'bottom',
+          color: textColorPrimary,
+          fontSize: 14,
+          width: 280,
+          overflow: 'truncate',
+        },
       },
       xAxis: {
         name: 'Enti fruitori attivi',
@@ -251,10 +273,10 @@ const TopEservices = ({ data }: TopEServicesProps) => {
       },
       series: seriesData,
       grid: {
-        left: '0%',
-        right: '3%',
-        bottom: isMobile ? '50%' : '20%',
-        containLabel: isMobile ? false : true,
+        right: 30,
+        left: 5,
+        top: 20,
+        bottom: 100,
       },
       legend: legend,
       legendSelectedMode: true,

--- a/src/components/numbers/TopEServices.tsx
+++ b/src/components/numbers/TopEServices.tsx
@@ -201,10 +201,10 @@ const TopEservices = ({ data }: TopEServicesProps) => {
     })
 
     const legend: echarts.LegendComponentOption = {
-      show: true,
+      show: isMobile ? false : true,
       bottom: 0,
       left: 'left',
-      selectedMode: true,
+      selectedMode: false,
       itemWidth: 12,
       itemHeight: 12,
       itemGap: 8,

--- a/src/components/numbers/TopEServices.tsx
+++ b/src/components/numbers/TopEServices.tsx
@@ -200,16 +200,6 @@ const TopEservices = ({ data }: TopEServicesProps) => {
       }
     })
 
-    const legend: echarts.LegendComponentOption = {
-      show: isMobile ? false : true,
-      bottom: 0,
-      left: 'left',
-      selectedMode: false,
-      itemWidth: 12,
-      itemHeight: 12,
-      itemGap: 8,
-    }
-
     return {
       textStyle: {
         fontFamily,
@@ -276,9 +266,8 @@ const TopEservices = ({ data }: TopEServicesProps) => {
         right: 30,
         left: 5,
         top: 20,
-        bottom: 100,
+        bottom: 55,
       },
-      legend: legend,
       legendSelectedMode: true,
     } as echarts.EChartsOption
   }, [currentData])
@@ -298,7 +287,7 @@ const TopEservices = ({ data }: TopEServicesProps) => {
         notMergeData
         chartOptions={chartOptions}
         tableData={tableData}
-        chartHeight={580}
+        chartHeight={480}
         info={Info}
         ariaLabel={`Grafico che mostra la top 10 degli enti che pubblicano più e-service. ${tableData.body
           .map((i) => `${i[0]} con ${i[1]} iscritti`)


### PR DESCRIPTION
Charts : "E-service più utilizzati, per enti fruitori attivi" now has the same style of others charts available on the page
