### PR TITLE
Top Producers By Subscribers chart fix

### DIFF
--- a/src/components/numbers/TopProducersBySubscribers.tsx
+++ b/src/components/numbers/TopProducersBySubscribers.tsx
@@ -101,7 +101,6 @@ const TopProducersBySubscribers = ({ data }: { data: TopProducersBySubscribersMe
         }))
       )
       .sort((a, b) => b.value - a.value)
-      .slice(0, NUMBERS_OF_ELEMENTS_TO_SHOW)
 
     const names = uniq(
       links.reduce(


### PR DESCRIPTION
remove the limit of max 10 categories for subscribers in the chart "Top Producers By Subscribers"