### PR TITLE
reorder timeframe Select Input

### DIFF
--- a/src/components/numbers/NumbersPageContent.tsx
+++ b/src/components/numbers/NumbersPageContent.tsx
@@ -19,10 +19,12 @@ type NumberPageContentProps = {
   data: Metrics
 }
 
+const labelOrder = (arr: string[]) => (label: string) => arr.indexOf(label)
+
 const NumbersPageContent: React.FC<NumberPageContentProps> = ({ data }) => {
   const tenantsLabels = ['Totale enti', 'Enti pubblici', 'Enti privati']
 
-  const getTenantsLabelOrder = (label: string) => tenantsLabels.indexOf(label)
+  const getTenantsLabelOrder = labelOrder(tenantsLabels)
 
   const tenantsCard = data.totaleEnti
     .filter((el) => tenantsLabels.includes(el.name))
@@ -42,7 +44,7 @@ const NumbersPageContent: React.FC<NumberPageContentProps> = ({ data }) => {
     'Altri enti pubblici',
   ]
 
-  const getPublicTenantsLabelOrder = (label: string) => publicTenants.indexOf(label)
+  const getPublicTenantsLabelOrder = labelOrder(publicTenants)
 
   const macrocategoriesCard = data.totaleEnti
     .filter((el) => !tenantsLabels.includes(el.name))
@@ -60,7 +62,7 @@ const NumbersPageContent: React.FC<NumberPageContentProps> = ({ data }) => {
     'Enti con avviati gli sviluppi tecnici',
   ]
 
-  const getTenantsActivityOrder = (label: string) => tenantByActivity.indexOf(label)
+  const getTenantsActivityOrder = labelOrder(tenantByActivity)
 
   const sortTenantActivity = (
     arr: Metrics['distribuzioneDegliEntiPerAttivita']

--- a/src/components/numbers/TimeframeSelectInput.tsx
+++ b/src/components/numbers/TimeframeSelectInput.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
 import { Timeframe } from '@/models/numbers.models'
 import { getLocalizedValue } from '@/utils/common.utils'
+import React from 'react'
 import { SelectInput } from './SelectInput'
 
 type TimeframeSelectInputProps = {
@@ -16,12 +16,12 @@ export const TimeframeSelectInput: React.FC<TimeframeSelectInputProps> = ({ valu
       onChange={onChange}
       options={[
         {
-          value: 'lastTwelveMonths',
-          label: getLocalizedValue({ it: 'Ultimi 12 mesi', en: 'Last 12 months' }),
-        },
-        {
           value: 'lastSixMonths',
           label: getLocalizedValue({ it: 'Ultimi 6 mesi', en: 'Last 6 months' }),
+        },
+        {
+          value: 'lastTwelveMonths',
+          label: getLocalizedValue({ it: 'Ultimi 12 mesi', en: 'Last 12 months' }),
         },
         {
           value: 'fromTheBeginning',


### PR DESCRIPTION
The ordering of the Timeframe Select Input is now: 
  - last 6 months
  - last 12 months
  - from the beginning


refactor of a function in NumbersPageContent.tsx