### PR TITLE
BI-1847 - add spaces to donut chart and stacked barchart

### DIFF
--- a/src/components/numbers/EServicesByTenantDistribution.tsx
+++ b/src/components/numbers/EServicesByTenantDistribution.tsx
@@ -99,6 +99,11 @@ const EServicesByTenantDistribution = ({
         center: ['50%', 140],
         type: 'pie',
         radius: [80, 120],
+        itemStyle: {
+          borderRadius: 5,
+          borderColor: '#fff',
+          borderWidth: 2,
+        },
         avoidLabelOverlap: true,
         label: {
           show: false,

--- a/src/components/numbers/TopEServices.tsx
+++ b/src/components/numbers/TopEServices.tsx
@@ -183,6 +183,10 @@ const TopEservices = ({ data }: TopEServicesProps) => {
         name: macrocategoryName,
         type: 'bar',
         stack: 'total',
+        itemStyle: {
+          borderColor: '#fff',
+          borderWidth: 0.5,
+        },
         label: {
           show: false,
           position: 'insideRight',


### PR DESCRIPTION
add spaces to:
- donut chart in “Distribution of entities by activity” 
- stacked barchart in “Most used E-service, by active user entities”